### PR TITLE
fix: php74 compatibility

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -111,7 +111,7 @@ class Repository extends ArrayRepository
 
         if (!isset($package['version'])) {
             $versionData        = $this->versionGuesser->guessVersion($package, $path);
-            $package['version'] = $versionData['version'] ?: 'dev-master';
+            $package['version'] = $versionData['version'] ?? 'dev-master';
         }
 
         $output = '';


### PR DESCRIPTION
Composer fails when using this plugin on PHP 7.4.
The shorthand ternary operator throws a notice error on null values since PHP 7.4. This PR fixes that issue.